### PR TITLE
Configure "Compile Examples" workflow for authenticated API requests

### DIFF
--- a/.github/workflows/compile-fw.yml
+++ b/.github/workflows/compile-fw.yml
@@ -39,6 +39,7 @@ jobs:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
           enable-deltas-report: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           libraries: |
             - source-path: ./
             - name: 107-Arduino-MCP2515


### PR DESCRIPTION
The  GitHub Actions action used in the "Compile Examples" workflow queries the GitHub API for the base ref of the pull request, which is used for the memory deltas determination.

GitHub does rate limiting of API requests and if the limit is exceeded, a spurious failure of the workflow run will occur, as was happening previously.

Authenticated API requests are given a more generous API request allowance, so providing the action with the automatically generated GitHub access token stored in  to use for the API requests should prevent any further workflow run failures caused by rate limiting.